### PR TITLE
get_name() causes warning/error

### DIFF
--- a/demo/addons/godot-krita-importer/godot-krita-importer.gd
+++ b/demo/addons/godot-krita-importer/godot-krita-importer.gd
@@ -9,9 +9,6 @@ extends EditorPlugin
 
 var import_plugin = null
 
-func get_name() -> StringName:
-	return "Godot Krita Importer"
-
 func _enter_tree():
 	import_plugin = preload("krita_import_plugin.gd").new()
 	add_import_plugin(import_plugin)


### PR DESCRIPTION
Not sure if this is specific to Godot 4.6, but this `get_name()` method produces a warning when activating the addon; according to Godot, it's shadowing a `Node` method and won't actually get called by anything.

Not sure if you want/need to update `godot-cpp` though.
